### PR TITLE
feat: enable shell completion for CLI commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,10 @@ anova-cli --version
 # Get help for any command
 anova-cli --help
 anova-cli status --help
+
+# Enable shell completion (bash, zsh, fish, PowerShell)
+anova-cli --install-completion
+anova-cli --show-completion  # Show completion script to copy manually
 ```
 
 ## Device Discovery

--- a/src/anovable/cli.py
+++ b/src/anovable/cli.py
@@ -15,7 +15,7 @@ from .exceptions import AnovaError
 app = typer.Typer(
     name="anova-cli",
     help="Control Anova Precision Cooker via Bluetooth LE",
-    add_completion=False,
+    add_completion=True,
 )
 
 


### PR DESCRIPTION
- Enable Typer's built-in completion system by setting add_completion=True
- Add --install-completion and --show-completion options to CLI
- Support tab completion for all commands and options across shells
- Update README with completion installation instructions
- Works with bash, zsh, fish, and PowerShell